### PR TITLE
Fix Household check

### DIFF
--- a/src/aiomealie/mealie.py
+++ b/src/aiomealie/mealie.py
@@ -164,7 +164,7 @@ class MealieClient:
         """Check whether households are supported."""
         try:
             await self._get("api/households/mealplans/today")
-        except MealieNotFoundError:
+        except MealieError:
             self.household_support = False
         else:
             self.household_support = True


### PR DESCRIPTION
# Proposed Changes

Change to MealieError as the household check actually returns a HTML page rather than a 404

`aiomealie.exceptions.MealieError: ('Unexpected response from Mealie', {'Content-Type': 'text/html; charset=utf-8', 'response': '<!doctype html>\n<html lang="en" data-n-head="%7B%22lang%22:%7B%221%22:%22en%22%7D%7D">\n  <head>\n    <meta data-n-head="1" data-hid="og:type" property="og:type" content="website"><meta data-n-head="1" data-hid="og:title" property="og:title" content="Mealie"><meta data-n-head="1" data-hid="og:site_name" property="og:site_name" content="Mealie"><meta data-n-head="1" data-hid="og:description" property="og:description" content="Mealie is a recipe management app for your kitchen."><meta data-n-head="1" data-hid="og:image" property="og:image" content="https://raw.githubusercontent.com/mealie-recipes/mealie/9571816ac4eed5beacfc0abf6c03eff1427fd0eb/frontend/static/icons/android-chrome-512x512.png"><meta data-n-head="1" charset="utf-8"><meta data-n-head="1" name="viewport" content="width=device-width,initial-scale=1"><meta data-n-head="1" data-hid="description" name="description" content="Mealie is a recipe management app for your kitchen."><meta data-n-head="`

