### PR TITLE
Remove assert

### DIFF
--- a/src/aiomealie/mealie.py
+++ b/src/aiomealie/mealie.py
@@ -172,7 +172,6 @@ class MealieClient:
 
     def _versioned_path(self, path_end: str) -> str:
         """Return the path with a prefix based on household support detected."""
-        assert self.household_support
         if self.household_support:
             return "api/households/" + path_end
         return "api/groups/" + path_end


### PR DESCRIPTION
# Proposed Changes

Removed the assert, of course it can be false if household isn't supported so fails on Mealie v1.
Time is against me, I liked the idea of validating define_household_support had been called but removing for now.
