### PR TITLE
Fix cannot connect

### DIFF
--- a/src/aiomealie/mealie.py
+++ b/src/aiomealie/mealie.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from importlib import metadata
 from typing import TYPE_CHECKING, Any, Self
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ClientConnectionError
 from aiohttp.hdrs import METH_GET, METH_POST, METH_PUT, METH_DELETE
 from mashumaro.codecs.orjson import ORJSONDecoder
 from yarl import URL
@@ -87,6 +87,9 @@ class MealieClient:
                 )
         except asyncio.TimeoutError as exception:
             msg = "Timeout occurred while connecting to Mealie"
+            raise MealieConnectionError(msg) from exception
+        except ClientConnectionError as exception:
+            msg = "Client connection error"
             raise MealieConnectionError(msg) from exception
 
         if response.status == 400:

--- a/src/aiomealie/mealie.py
+++ b/src/aiomealie/mealie.py
@@ -89,7 +89,7 @@ class MealieClient:
             msg = "Timeout occurred while connecting to Mealie"
             raise MealieConnectionError(msg) from exception
         except ClientConnectionError as exception:
-            msg = "Client connection error"
+            msg = "Client connection error while connecting to Mealie"
             raise MealieConnectionError(msg) from exception
 
         if response.status == 400:

--- a/tests/test_mealie.py
+++ b/tests/test_mealie.py
@@ -172,6 +172,14 @@ async def test_timeout(
             assert await mealie_client.get_startup_info()
 
 
+async def test_client_connection_error() -> None:
+    """Test client connection error from mealie."""
+
+    async with MealieClient(api_host="https://bad-url") as mealie_client:
+        with pytest.raises(MealieConnectionError):
+            assert await mealie_client.get_startup_info()
+
+
 async def test_about(
     responses: aioresponses,
     mealie_client: MealieClient,


### PR DESCRIPTION
# Proposed Changes

Throw proper mealie connection error when unable to connect to client to allow retry.

## Related Issues

https://github.com/home-assistant/core/issues/126906

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
