### PR TITLE
Update Ingredient model to return food item

### DIFF
--- a/src/aiomealie/models.py
+++ b/src/aiomealie/models.py
@@ -109,6 +109,7 @@ class Ingredient(DataClassORJSONMixin):
     quantity: float | None
     note: str
     unit: str | None
+    food: str | None
     is_food: bool = field(metadata=field_options(alias="isFood"))
     reference_id: str = field(metadata=field_options(alias="referenceId"))
 


### PR DESCRIPTION
# Proposed Changes
When I tried making a card in Home Assistant to show todays recipe ingredients and instructions with get_recipe, the actual food item wasn't in the response. This should fix that, so ingredients look like this:
```yaml
ingredients:
    - quantity:
      note:
      unit: ...
      food:
        id: 
        name: 
        pluralName: 
        description: ""
        extras: {}
        onHand:
        labelId:
        aliases: []
        label:
        createdAt: 
        updatedAt: 
      is_food:
      reference_id:
```