### PR TITLE
Change is_food and disable_amount to be optional

### DIFF
--- a/src/aiomealie/models.py
+++ b/src/aiomealie/models.py
@@ -109,8 +109,8 @@ class Ingredient(DataClassORJSONMixin):
     quantity: float | None
     note: str
     unit: str | None
-    is_food: bool = field(metadata=field_options(alias="isFood"))
     reference_id: str = field(metadata=field_options(alias="referenceId"))
+    is_food: bool | None = field(default=None, metadata=field_options(alias="isFood"))
 
 
 @dataclass
@@ -246,12 +246,14 @@ class ShoppingItem(DataClassORJSONMixin):
     display: str
     checked: bool
     position: int
-    is_food: bool = field(metadata=field_options(alias="isFood"))
-    disable_amount: bool = field(metadata=field_options(alias="disableAmount"))
     quantity: float
     label_id: str | None = field(default=None, metadata=field_options(alias="labelId"))
     food_id: str | None = field(default=None, metadata=field_options(alias="foodId"))
     unit_id: str | None = field(default=None, metadata=field_options(alias="unitId"))
+    is_food: bool | None = field(default=None, metadata=field_options(alias="isFood"))
+    disable_amount: bool | None = field(
+        default=None, metadata=field_options(alias="disableAmount")
+    )
 
 
 @dataclass

--- a/tests/__snapshots__/test_mealie.ambr
+++ b/tests/__snapshots__/test_mealie.ambr
@@ -2766,10 +2766,10 @@
     'items': list([
       dict({
         'checked': False,
-        'disable_amount': True,
+        'disable_amount': None,
         'display': '2 Apples',
         'food_id': None,
-        'is_food': False,
+        'is_food': None,
         'item_id': 'f45430f7-3edf-45a9-a50f-73bb375090be',
         'label_id': None,
         'list_id': '9ce096fe-ded2-4077-877d-78ba450ab13e',

--- a/tests/fixtures/shopping_items.json
+++ b/tests/fixtures/shopping_items.json
@@ -9,8 +9,6 @@
             "unit": null,
             "food": null,
             "note": "Apples",
-            "isFood": false,
-            "disableAmount": true,
             "display": "2 Apples",
             "shoppingListId": "9ce096fe-ded2-4077-877d-78ba450ab13e",
             "checked": false,


### PR DESCRIPTION
# Proposed Changes

Make fields optional.
This will still require handling within the integration.

## Related Issues

https://github.com/home-assistant/core/issues/149840

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
