### PR TITLE
Add fields enhancement

### DIFF
--- a/src/aiomealie/models.py
+++ b/src/aiomealie/models.py
@@ -138,6 +138,9 @@ class BaseRecipe(DataClassORJSONMixin):
     group_id: str = field(metadata=field_options(alias="groupId"))
     name: str
     slug: str
+    totalTime: str
+    prepTime: str
+    performTime: str
     description: str
     image: str | None = None
     recipe_yield: str | None = field(

--- a/src/aiomealie/models.py
+++ b/src/aiomealie/models.py
@@ -138,9 +138,6 @@ class BaseRecipe(DataClassORJSONMixin):
     group_id: str = field(metadata=field_options(alias="groupId"))
     name: str
     slug: str
-    totalTime: str = field(metadata=field_options(alias="totalTime"))
-    prepTime: str = field(metadata=field_options(alias="prepTime"))
-    performTime: str = field(metadata=field_options(alias="performTime"))
     description: str
     image: str | None = None
     recipe_yield: str | None = field(
@@ -164,6 +161,27 @@ class Recipe(BaseRecipe):
 
     tags: list[Tag]
     date_added: date = field(metadata=field_options(alias="dateAdded"))
+    totalTime: str = field(
+        default=None,
+        metadata=field_options(
+            alias="totalTime",
+            serialization_strategy=OptionalStringSerializationStrategy(),
+        ),
+    )
+    prepTime: str = field(
+        default=None,
+        metadata=field_options(
+            alias="prepTime",
+            serialization_strategy=OptionalStringSerializationStrategy(),
+        ),
+    )
+    performTime: str = field(
+        default=None,
+        metadata=field_options(
+            alias="performTime",
+            serialization_strategy=OptionalStringSerializationStrategy(),
+        ),
+    )
     ingredients: list[Ingredient] = field(
         metadata=field_options(alias="recipeIngredient")
     )

--- a/src/aiomealie/models.py
+++ b/src/aiomealie/models.py
@@ -138,9 +138,9 @@ class BaseRecipe(DataClassORJSONMixin):
     group_id: str = field(metadata=field_options(alias="groupId"))
     name: str
     slug: str
-    totalTime: str
-    prepTime: str
-    performTime: str
+    totalTime: str = field(metadata=field_options(alias="totalTime"))
+    prepTime: str = field(metadata=field_options(alias="prepTime"))
+    performTime: str = field(metadata=field_options(alias="performTime"))
     description: str
     image: str | None = None
     recipe_yield: str | None = field(


### PR DESCRIPTION
# Proposed Changes enhancement
> Addition of three new optional time fields to the `Recipe` model to improve time metadata management in the Mealie Python API client.

The added fields are:
- `totalTime`: total recipe time (preparation + cooking)
- `prepTime`: preparation time only
- `performTime`: execution/cooking time

All fields use `OptionalStringSerializationStrategy()` and are configured with appropriate aliases for the Mealie API. The change is fully backward compatible as all new fields have a default value of `None`.

## Related Issues
> (No specific related issue, functional improvement)