### PR TITLE
Remove v1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Asynchronous Python client for Mealie.
 
 This package allows you to fetch data from your Mealie instance.
 
+Mealie instances of version 2 and above are supported.
+
 ## Installation
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,6 @@ async def client() -> AsyncGenerator[MealieClient, None]:
             session=session,
         ) as mealie_client,
     ):
-        mealie_client.household_support = True
         yield mealie_client
 
 

--- a/tests/test_mealie.py
+++ b/tests/test_mealie.py
@@ -628,29 +628,3 @@ async def test_set_mealplan(
         }
         | data,
     )
-
-
-async def test_household_support(
-    responses: aioresponses,
-    mealie_client: MealieClient,
-) -> None:
-    """Test household support."""
-    responses.get(f"{MEALIE_URL}/api/households/mealplans/today", status=404, body="")
-    assert await mealie_client.define_household_support() is False
-    assert mealie_client.household_support is False
-
-
-async def test_no_household_support(
-    responses: aioresponses,
-    mealie_client: MealieClient,
-) -> None:
-    """Test no household support."""
-    mealie_client.household_support = None
-
-    responses.get(
-        f"{MEALIE_URL}/api/households/mealplans/today",
-        status=200,
-        body=load_fixture("mealplan_today.json"),
-    )
-    assert await mealie_client.define_household_support() is True
-    assert mealie_client.household_support is True


### PR DESCRIPTION
# Proposed Changes

Drop support for Mealie v1, removing all conditional api paths and the household_support field.

This should be a major version increment release due to the breaking change.
