### PR TITLE
Remove non-existent recipeSlug field from RecipeRating

### DIFF
--- a/src/aiomealie/models.py
+++ b/src/aiomealie/models.py
@@ -531,9 +531,6 @@ class RecipeRating(DataClassORJSONMixin):
 
     recipe_id: str = field(metadata=field_options(alias="recipeId"))
     is_favorite: bool = field(metadata=field_options(alias="isFavorite"))
-    recipe_slug: str | None = field(
-        default=None, metadata=field_options(alias="recipeSlug")
-    )
     rating: float | None = None
 
 

--- a/tests/__snapshots__/test_mealie.ambr
+++ b/tests/__snapshots__/test_mealie.ambr
@@ -393,13 +393,11 @@
         'is_favorite': True,
         'rating': 4.5,
         'recipe_id': '40393996-417e-4487-a081-28608a668826',
-        'recipe_slug': 'cauliflower-salad',
       }),
       dict({
         'is_favorite': True,
         'rating': None,
         'recipe_id': 'e1f2a3b4-c5d6-7890-abcd-ef1234567890',
-        'recipe_slug': 'original-sacher-torte-2',
       }),
     ]),
   })

--- a/tests/fixtures/recipe_favorites.json
+++ b/tests/fixtures/recipe_favorites.json
@@ -2,13 +2,11 @@
     "ratings": [
         {
             "recipeId": "40393996-417e-4487-a081-28608a668826",
-            "recipeSlug": "cauliflower-salad",
             "rating": 4.5,
             "isFavorite": true
         },
         {
             "recipeId": "e1f2a3b4-c5d6-7890-abcd-ef1234567890",
-            "recipeSlug": "original-sacher-torte-2",
             "rating": null,
             "isFavorite": true
         }


### PR DESCRIPTION
# Proposed Changes

`RecipeRating` declares a `recipe_slug` attribute mapped to the `recipeSlug` alias, but the Mealie API never returns such a field, so the attribute was always `None`.

Checking the `openapi.json` vendored in this repository:

- `GET /api/users/self/favorites` and `GET /api/users/self/ratings` return
  `UserRatings[UserRatingSummary]`, and `UserRatingSummary` only defines `recipeId`,
  `rating` and `isFavorite`.
- `GET /api/users/{id}/favorites` and `GET /api/users/{id}/ratings` return
  `UserRatings[UserRatingOut]`, which adds `userId` and `id` — still no slug.

The field was introduced in #738 (my own PR), so this is a follow-up fix on my side.

This PR:

- removes `recipe_slug` from `RecipeRating`;
- removes the `recipeSlug` keys from `tests/fixtures/recipe_favorites.json`, so the
  fixture matches a real API response;
- updates the `test_get_recipe_favorites` snapshot accordingly.

`RecipeRating` is part of the public API (exported from `aiomealie/__init__.py`), so strictly speaking this removes a public attribute. Since it could only ever be `None`, no caller can meaningfully depend on its value. Callers that need a slug are unaffected: `add_recipe_favorite`, `remove_recipe_favorite` and `rate_recipe` already take the slug as an argument, and it can be resolved from `recipe_id` through the recipe endpoints.
